### PR TITLE
Issue NuCivic/dkan#228: Fix exception deleting dataset if field_link_remote_file is removed from Resource fields

### DIFF
--- a/dkan_datastore.module
+++ b/dkan_datastore.module
@@ -231,7 +231,7 @@ function dkan_datastore_node_update($node) {
     // See if we have a file link or upload.
     $wrapper = entity_metadata_wrapper('node', $node);
     $file = $wrapper->field_upload->value();
-    if (!$file) {
+    if (!$file && $wrapper->__isset("field_link_remote_file")) {
       $link = $wrapper->field_link_remote_file->value();
       if (isset($link) && isset($link['fid'])) {
         $file = file_load($link['fid']);


### PR DESCRIPTION
NuCivic/dkan#228
