### PR TITLE
Make DATA API button smarter

### DIFF
--- a/dkan_datastore.module
+++ b/dkan_datastore.module
@@ -148,24 +148,28 @@ function dkan_datastore_feeds_access($action, $node) {
  * Access callback for Data API instructions.
  */
 function dkan_datastore_datastore_api_access($resource) {
-  $file_field = dkan_datastore_file_upload_field();
-  $link_field = dkan_datastore_file_link_field();
-  $type = dkan_datastore_node_type();
-  $node = is_object($resource) ? $resource : node_load($resource);
-  $upload = '';
-  $link = '';
-  if (isset($node->$file_field) && $node->$file_field) {
-    $upload = isset($node->{$file_field}[$node->language]) ? $node->{$file_field}[$node->language] : $node->{$file_field}['und'];
+  $status = dkan_datastore_status($resource);
+  if ($status != DKAN_DATASTORE_WRONG_TYPE) {
+    $file_field = dkan_datastore_file_upload_field();
+    $link_field = dkan_datastore_file_link_field();
+    $type = dkan_datastore_node_type();
+    $node = is_object($resource) ? $resource : node_load($resource);
+    $upload = '';
+    $link = '';
+    if (isset($node->$file_field) && $node->$file_field) {
+      $upload = isset($node->{$file_field}[$node->language]) ? $node->{$file_field}[$node->language] : $node->{$file_field}['und'];
+    }
+    if (isset($node->{$link_field}) && $node->{$link_field}) {
+      $link = isset($node->{$link_field}[$node->language]) ? $node->{$link_field}[$node->language] : $node->{$link_field}['und'];
+    }
+    if ($node->type == $type && ($upload || $link)) {
+      return node_access('view', $node);
+    }
+    else {
+      return FALSE;
+    }
   }
-  if (isset($node->{$link_field}) && $node->{$link_field}) {
-    $link = isset($node->{$link_field}[$node->language]) ? $node->{$link_field}[$node->language] : $node->{$link_field}['und'];
-  }
-  if ($node->type == $type && ($upload || $link)) {
-    return node_access('view', $node);
-  }
-  else {
-    return FALSE;
-  }
+  return FALSE;
 }
 
 /**
@@ -342,9 +346,9 @@ function dkan_datastore_records($nid) {
 /**
  * Retrieves loaded file from resource node.
  */
-function dkan_datastore_file_field($node) {
+function dkan_datastore_file_field($node) {  
   $type = dkan_datastore_node_type();
-  if ($node->type == $type) {
+  if (isset($node->type) && $node->type == $type) {
     $file_field = dkan_datastore_file_upload_field();
     $link_field = dkan_datastore_file_link_field();
     $wrapper = entity_metadata_wrapper('node', $node);

--- a/dkan_datastore.pages.inc
+++ b/dkan_datastore.pages.inc
@@ -9,9 +9,22 @@
  * Callback for Data API instructions.
  */
 function dkan_datastore_datastore_api($node) {
-  $datastore = dkan_datastore_go($node->uuid);
-  $output = $datastore->apiForm();
-  return $output;
+  $status = dkan_datastore_status($node);
+  switch ($status) {
+    case DKAN_DATASTORE_EXISTS:
+      $datastore = dkan_datastore_go($node->uuid);
+      $output = $datastore->apiForm();
+      return $output;
+    case DKAN_DATASTORE_FILE_EXISTS:
+      drupal_set_message(t('You need to add your file to the datastore in order to use the DATA API'));
+      $redirect_path = 'node/' . $node->nid . '/datastore';
+      break;
+    default:
+      drupal_set_message(t('This resource can not be added to the datastore'));
+      $redirect_path = 'node/' . $node->nid;
+      break;
+  }
+  drupal_goto($redirect_path);
 }
 
 /**


### PR DESCRIPTION
nuams/usda-nal#421
### Acceptance Test
- [x] If resource can be added to the datastore clicking the DATA API button will redirect the user to **Manage Datastore** and display a message to the user about why it's being redirected
- [x] If the resource can not be added to the datastore the button is hidden
