### PR TITLE
Make data api button smarter

### DIFF
--- a/dkan_datastore.module
+++ b/dkan_datastore.module
@@ -148,24 +148,31 @@ function dkan_datastore_feeds_access($action, $node) {
  * Access callback for Data API instructions.
  */
 function dkan_datastore_datastore_api_access($resource) {
-  $file_field = dkan_datastore_file_upload_field();
-  $link_field = dkan_datastore_file_link_field();
-  $type = dkan_datastore_node_type();
-  $node = is_object($resource) ? $resource : node_load($resource);
-  $upload = '';
-  $link = '';
-  if (isset($node->$file_field) && $node->$file_field) {
-    $upload = isset($node->{$file_field}[$node->language]) ? $node->{$file_field}[$node->language] : $node->{$file_field}[LANGUAGE_NONE];
-  }
-  if (isset($node->{$link_field}) && $node->{$link_field}) {
-    $link = isset($node->{$link_field}[$node->language]) ? $node->{$link_field}[$node->language] : $node->{$link_field}[LANGUAGE_NONE];
-  }
-  if ($node->type == $type && ($upload || $link)) {
-    return node_access('view', $node);
-  }
-  else {
+  $status = dkan_datastore_status($resource);
+  if ($status == DKAN_DATASTORE_FILE_EXISTS && !user_access('manage datastore')) {
     return FALSE;
   }
+  if ($status != DKAN_DATASTORE_WRONG_TYPE) {
+    $file_field = dkan_datastore_file_upload_field();
+    $link_field = dkan_datastore_file_link_field();
+    $type = dkan_datastore_node_type();
+    $node = is_object($resource) ? $resource : node_load($resource);
+    $upload = '';
+    $link = '';
+    if (isset($node->$file_field) && $node->$file_field) {
+      $upload = isset($node->{$file_field}[$node->language]) ? $node->{$file_field}[$node->language] : $node->{$file_field}['und'];
+    }
+    if (isset($node->{$link_field}) && $node->{$link_field}) {
+      $link = isset($node->{$link_field}[$node->language]) ? $node->{$link_field}[$node->language] : $node->{$link_field}['und'];
+    }
+    if ($node->type == $type && ($upload || $link)) {
+      return node_access('view', $node);
+    }
+    else {
+      return FALSE;
+    }
+  }
+  return FALSE;
 }
 
 /**
@@ -344,7 +351,7 @@ function dkan_datastore_records($nid) {
  */
 function dkan_datastore_file_field($node) {
   $type = dkan_datastore_node_type();
-  if ($node->type == $type) {
+  if (isset($node->type) && $node->type == $type) {
     $file_field = dkan_datastore_file_upload_field();
     $link_field = dkan_datastore_file_link_field();
     $wrapper = entity_metadata_wrapper('node', $node);

--- a/dkan_datastore.pages.inc
+++ b/dkan_datastore.pages.inc
@@ -9,9 +9,22 @@
  * Callback for Data API instructions.
  */
 function dkan_datastore_datastore_api($node) {
-  $datastore = dkan_datastore_go($node->uuid);
-  $output = $datastore->apiForm();
-  return $output;
+  $status = dkan_datastore_status($node);
+  switch ($status) {
+    case DKAN_DATASTORE_EXISTS:
+      $datastore = dkan_datastore_go($node->uuid);
+      $output = $datastore->apiForm();
+      return $output;
+    case DKAN_DATASTORE_FILE_EXISTS:
+      drupal_set_message(t('You need to add your file to the datastore in order to use the DATA API'));
+      $redirect_path = 'node/' . $node->nid . '/datastore';
+      break;
+    default:
+      drupal_set_message(t('This resource can not be added to the datastore'));
+      $redirect_path = 'node/' . $node->nid;
+      break;
+  }
+  drupal_goto($redirect_path);
 }
 
 /**


### PR DESCRIPTION
- [x] A user that's not logged in or does not have permissions to manage the datastore shouldn't see the DATA Api button
- [x] If the resource is added to the datastore any user should see the `DATA api button`
- [x] If a resource can be added to the datastore clicking the `DATA api button` will redirect the user to the `manage datastore` page
- [x] If a resource can't be added to the datastore then the button is hidden.
