### PR TITLE
Fix NuCivic/saturn#21. Add uuid suport to download links.

### DIFF
--- a/dkan_datastore.module
+++ b/dkan_datastore.module
@@ -17,12 +17,12 @@ include_once "dkan_datastore.features.inc";
  * Implements hook_menu().
  */
 function dkan_datastore_menu() {
-  $items['node/%node/download'] = array(
+  $items['node/%dkan_datastore_resource/download'] = array(
     'title' => 'Download',
     'page callback' => 'dkan_datastore_download',
     'page arguments' => array(1),
-    'access callback' => 'dkan_datastore_download_access',
-    'access arguments' => array(1),
+    'access callback' => 'node_access',
+    'access arguments' => array('view', 1),
     'file' => 'dkan_datastore.pages.inc',
     'weight' => '20',
     'type' => MENU_LOCAL_TASK,
@@ -169,26 +169,26 @@ function dkan_datastore_datastore_api_access($resource) {
 }
 
 /**
- * Access callback for download tab.
+ * Load node by id or uuid.
  */
-function dkan_datastore_download_access($node) {
-  $upload = '';
-  $link = '';
-  $file_field = dkan_datastore_file_upload_field();
-  $link_field = dkan_datastore_file_link_field();
-  $type = dkan_datastore_node_type();
-  if (isset($node->$file_field) && $node->$file_field) {
-    $upload = isset($node->{$file_field}[$node->language]) ? $node->{$file_field}[$node->language] : $node->{$file_field}[LANGUAGE_NONE];
+function dkan_datastore_resource_load($id) {
+  try {
+    // Id is a nid.
+    if (is_numeric($id)) {
+      return node_load($id);
+    }
+    // Id is a uuid and uuid is installed.
+    else if (function_exists('entity_uuid_load')) {
+      $node = entity_uuid_load('node', array($id));
+      return ($node) ? reset($node) : FALSE;
+    }
+
   }
-  if (isset($node->$link_field) && $node->$link_field) {
-    $link = isset($node->{$link_field}[$node->language]) ? $node->{$link_field}[$node->language] : $node->{$link_field}[LANGUAGE_NONE];
-  }
-  if ($node->type == $type && ($upload || $link)) {
-    return node_access('view', $node);
-  }
-  else {
+  catch (Exception $e) {
     return FALSE;
   }
+
+  return FALSE;
 }
 
 /**
@@ -411,7 +411,7 @@ function dkan_datastore_theme() {
  *
  * @ingroup themeable
  */
-function theme_dkan_datastore_status_formatter($variables) {
+function theme_dkan_datastore_status_formatter(array $variables) {
   $status = dkan_datastore_status($variables['item']['entity']);
   if ($status === DKAN_DATASTORE_FILE_EXISTS) {
     return '<span class="circle false" title="' . t('A file has been uploaded but not added to the datastore') . '">' . t('Data ready to be added') . '</span>';

--- a/dkan_datastore.pages.inc
+++ b/dkan_datastore.pages.inc
@@ -20,8 +20,9 @@ function dkan_datastore_datastore_api($node) {
 function dkan_datastore_download($node) {
   $node_wrapper = entity_metadata_wrapper('node', $node);
   $file_field = dkan_datastore_file_upload_field();
-  $link_field = dkan_datastore_file_link_field();
-  if ($file = $node_wrapper->{$file_field}->value()) {
+  $type = dkan_datastore_node_type();
+
+  if ($node->type == $type && $file = $node_wrapper->{$file_field}->value()) {
     $uri = isset($file->uri) ? $file->uri : $file['uri'];
     $url = file_create_url($uri);
     return drupal_goto($url);


### PR DESCRIPTION
Because we use uuid reference inside visualization_entity module then
we need to have a way to reference download links using a uuid instead
of nid.
### Acceptance test
- [x] git pull
- [x] go to a resource
- [x] copy the download link
- [x] paste it into a new window and enter
- [x] file should be downloaded
- [x] change nid by uuid of resource
- [x] file should be downloaded
- [x] unpublish resource
- [x] try to download from a incognito window (both methods)
- [x] access should be denied
- [x] change uuid or nid in the url by a random string
- [x] try to download 
- [x] 404 page should be displayed
