### PR TITLE
Updating dkan_datastore with search results view mode

### DIFF
--- a/dkan_datastore.features.field_instance.inc
+++ b/dkan_datastore.features.field_instance.inc
@@ -27,6 +27,12 @@ function dkan_datastore_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 7,
       ),
+      'search_result' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),


### PR DESCRIPTION
![screenshot_3_24_16__10_12_am](https://cloud.githubusercontent.com/assets/314172/14021300/f1fe07c2-f1a8-11e5-9072-7341ffde95cd.png)
## Issue

dkan_datastore displays as overridden because a new view mode was added but not captured in the feature.
