### PR TITLE
Add hook_update function to enable field_hidden

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+7.x-1.12 2015-04-01
+--------------------------
+- Add update function enable field_hidden module
+
 7.x-1.10 2015-11-10
 --------------------------
 - Upgrade Feeds module to latest dev version

--- a/dkan_datastore.install
+++ b/dkan_datastore.install
@@ -19,3 +19,11 @@ function dkan_datastore_install() {
     ->execute();
 
 }
+
+
+/**
+ * Implements hook_update_N().
+ */
+function dkan_datastore_update_7001() {
+  module_enable(array('field_hidden'));
+}


### PR DESCRIPTION
## Background

A field called field_datastore_status was added to the resource content type to support large file imports. But the hidden_integer module is not enabled on upgrade.
## Acceptance test
- [x] An upgrade from 7.x-1.11 should not cause any errors
- [x] After upgrade the resource content type should have the field_datastore_status.

Here is a dump of a clean 7.x-1.11 install:

[7-x-1-11.sql.zip](https://github.com/NuCivic/dkan_datastore/files/198704/7-x-1-11.sql.zip)
