### PR TITLE
When an unexpected error happen an array with an error string message inside.

### DIFF
--- a/modules/dkan_datastore_api/dkan_datastore_api.module
+++ b/modules/dkan_datastore_api/dkan_datastore_api.module
@@ -322,7 +322,7 @@ function _dkan_datastore_api_datastore_index($resource_ids, $filters, $query, $o
     }
   }
   catch (Exception $ex) {
-    return array('Caught exception: ' . $ex->getMessage());
+    return array('error' => array('message' => 'Caught exception: ' . $ex->getMessage()));
   }
   $count = dkan_datastore_api_count($table, $offset, $limit, $fields, $filters, $query);
   $results = services_resource_execute_index_query($data_select);


### PR DESCRIPTION
However since everything else return a json object the I changed that to 
standarize error messaging across client libraries.

`{error: {message: "Something bad happened"}}`
