### PR TITLE
Assume parsed json to be array of objects of form filters: [{key:val}…

### DIFF
--- a/modules/dkan_datastore_api/dkan_datastore_api.module
+++ b/modules/dkan_datastore_api/dkan_datastore_api.module
@@ -386,14 +386,9 @@ function dkan_datastore_api_add_index_conditions(&$data_select, $filters, $alias
     foreach ($filters as $num => $filter) {
       $num = str_replace(' ', '_', $num);
 
-      if (is_array($filter)) {
         foreach ($filter as $key => $value) {
-          $data_select->condition($num . '.' . $key, $filter, 'IN');
+          $data_select->condition($alias . '.' . $key, $filter, 'IN');
         }
-      }
-      else {
-        $data_select->condition($alias . '.' . $num, services_str_getcsv($filter), 'IN');
-      }
     }
   }
 }

--- a/modules/dkan_datastore_api/tests/phpunit/DkanDatastoreAPITest.php
+++ b/modules/dkan_datastore_api/tests/phpunit/DkanDatastoreAPITest.php
@@ -117,7 +117,9 @@ class DkanDatastoreAPITest extends \PHPUnit_Framework_TestCase {
       ),
       'limit' => 1000,
       'filters' => array(
-        'date' => '1950-02-01'
+        array(
+          'date' => '1950-02-01'
+        )
       )
     );
     $params = _dkan_datastore_api_get_params($params);


### PR DESCRIPTION
Assume parsed json to be array of objects of form filters: [{key:val}…<-- js obj notation
## Description

I think the filters code assumed php-style arrays with string as key... I updated this to assume JS style of notation, which we would expect from parsed JSON object 
## Acceptance criteria
- Tests should pass - I'm not familiar with the workflow for running tests locally so I couldn't verify that all tests pass
- API Query of following form should return valid data:

``` javascript
{
  "by_age": {
    "group_by": "age",
    "count": "age",
    "resource_id": "0dab0a83-8572-4b5d-a802-0e188fbf44f4",
    "limit": 100,
    "fields": [
      "age"
    ],
    "filters": [
      {
        "County1": [40, 36]
      }
    ]
  }
}
```
