### PR TITLE
CIVIC-4709 Limit Size of Download Proxy

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+7.x-1.12.x
+----------
+- Cache recline embeds 
+
 7.x-1.12 2015-04-01
 --------------------------
 - Add update function enable field_hidden module

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 7.x-1.12.x
 ----------
-- Cache recline embeds 
+- Add limit to proxy resources.
 
 7.x-1.12 2015-04-01
 --------------------------

--- a/dkan-module-init.sh
+++ b/dkan-module-init.sh
@@ -3,7 +3,7 @@
 DKAN_MODULE=`ls *.info | cut -d'.' -f1`
 
 # DKAN branch or tag to use.
-DKAN_VERSION="7.x-1.x"
+DKAN_VERSION="release-1-12"
 
 COMPOSER_PATH="$HOME/.config/composer/vendor/bin"
 

--- a/dkan_datastore.pages.inc
+++ b/dkan_datastore.pages.inc
@@ -5,6 +5,9 @@
  * Callbacks for datastore pages.
  */
 
+// Default to 50MB.
+define('MAX_FILE_REMOTE_PROXY_DEFAULT', 1024 * 1024 * 50);
+
 /**
  * Callback for Data API instructions.
  */
@@ -40,10 +43,11 @@ function dkan_datastore_download($node) {
     return drupal_goto($url);
   }
   elseif ($type == 'remote') {
-    $size = isset($node_wrapper->field_link_remote_file->value()['filesize']) ? (int) $node_wrapper->field_link_remote_file->value()['filesize'] : int(0);
+    $size = isset($node_wrapper->field_link_remote_file->value()['filesize']) ? (int) $node_wrapper->field_link_remote_file->value()['filesize'] : 0;
+
     // dkan_datastore_proxy() loads the file locally which has a big memory footprint.
     // If the file is too large we don't want to proxy.
-    $max = (int) variable_get('dkan_datastore_max_file_remote_proxy_size', 50000000);
+    $max = (int) variable_get('dkan_datastore_max_file_remote_proxy_size', MAX_FILE_REMOTE_PROXY_DEFAULT);
     if ($size > $max) {
       drupal_goto($url);
     }

--- a/dkan_datastore.pages.inc
+++ b/dkan_datastore.pages.inc
@@ -36,15 +36,27 @@ function dkan_datastore_download($node) {
   $url = $link_type['url'];
   $type = $link_type['type'];
 
-  if($type == 'upload') {
+  if ($type == 'upload') {
     return drupal_goto($url);
-  } else if($type == 'remote') {
-    dkan_datastore_proxy($node);
-  } else if($type == 'link'){
+  }
+  elseif ($type == 'remote') {
+    $size = isset($node_wrapper->field_link_remote_file->value()['filesize']) ? (int) $node_wrapper->field_link_remote_file->value()['filesize'] : int(0);
+    // dkan_datastore_proxy() loads the file locally which has a big memory footprint.
+    // If the file is too large we don't want to proxy.
+    $max = (int) variable_get('dkan_datastore_max_file_remote_proxy_size', 50000000);
+    if ($size > $max) {
+      drupal_goto($url);
+    }
+    else {
+      dkan_datastore_proxy($node);
+    }
+  }
+  elseif ($type == 'link') {
     return drupal_goto($url);
-  } else {
+  }
+  else {
     drupal_set_message(t('No download available for this resource'));
-    return '';    
+    return '';
   }
 }
 


### PR DESCRIPTION
The remote linked file is proxied through a DKAN site so that we don't run into CORS issues for the visualizations. That can cause memory issues with large files. This only proxies files smaller than 50MB.