### PR TITLE
Revert dkan datastore in the 7001 update

### DIFF
--- a/dkan_datastore.install
+++ b/dkan_datastore.install
@@ -26,4 +26,5 @@ function dkan_datastore_install() {
  */
 function dkan_datastore_update_7001() {
   module_enable(array('field_hidden'));
+  features_revert(array('dkan_datastore' => array('field_base', 'field_instance')));
 }


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-3567

In order to make dkan_datastore_status field appear after a dkan upgrade we need to revert the dkan_datastore feature in the update hook 7001.

## PR Dependencies
https://github.com/NuCivic/dkan/pull/1491