### PR TITLE
[CIVIC-4971] Update Download button to support unallowed types #1576

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,8 @@
 7.x-1.12 2015-04-01
 --------------------------
 - Add update function enable field_hidden module
+- Better support of downloading remote files from the resource view page
+  "Download" button.
 
 7.x-1.10 2015-11-10
 --------------------------

--- a/dkan_datastore.pages.inc
+++ b/dkan_datastore.pages.inc
@@ -65,6 +65,10 @@ function dkan_datastore_proxy($node) {
     drupal_add_http_header('Content-Disposition', 'attachment; filename=' . $filename);
     print file_get_contents($uri);
   }
+  else {
+    // Not in allowed types, treat the file URI as a normal url.
+    return drupal_goto($uri);
+  }
 }
 
 /**


### PR DESCRIPTION
issue: CIVIC-4971

1.12 backport of https://github.com/NuCivic/dkan/pull/1576