### PR TITLE
Upgrade dkan datastore api to the most recent version

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 7.x-1.12.x
 ----------
 - Add limit to proxy resources.
+- Upgrade dkan_datastore_api.
 
 7.x-1.12 2015-04-01
 --------------------------

--- a/modules/dkan_datastore_api/README.md
+++ b/modules/dkan_datastore_api/README.md
@@ -1,113 +1,65 @@
 DKAN offers a Datastore API as a custom endpoint for the Drupal Services module.
 
-This API is designed to be as compatible as possible with the [CKAN Datastore API](http://ckan.readthedocs.org/en/latest/maintaining/datastore.html).
+This API is designed to be as compatible as possible with the CKAN Datastore API: http://ckan.readthedocs.org/en/latest/maintaining/datastore.html
 
-Requests can be sent over HTTP. Data can be returned as JSON, XML, or JSONP. The Datastore API supports both simple GET parameters and POST requests containing a JSON object specifying one or multiple queries.
+## Parameters
 
-## Datastore API URL
+-   **resource_id** (*mixed*) – id (string) or ids (array) of the resource to be searched against.
+-   **filters** (*mixed*) – array or string of matching conditions to select
+-   **q** (_string_) – full text query
+-   **offset** (*int*) – offset this number of rows
+-   **limit** (*int*) – maximum number of rows to return (default: 100)
+-   **fields** (*array or comma separated string*) – fields to return (default: all fields in original order)
+-   **sort** (*string*) – comma separated field names with ordering
+-   **join** (*array*) – array of fields to join from multiple tables
+-   **group_by** (*array*) – array of fields to group by
 
-Datastores can be queried at:  `/api/action/datastore/search`
-
-The default return format is XML. JSON can be retrieved with `.json` at the end:
-
-`/api/action/datastore/search.json`
-
-...as can JSONP or making XML more explicit:
-
-`/api/action/datastore/search.jsonp`
-
-`/api/action/datastore/search.xml`
-
-## Request Parameters
-
-* **resource_id** (_mixed_) – id (string) or ids (array) of the resource to be searched against.
-* **filters** (_mixed_) – array or string of matching conditions to select
-* **q** (_string_) – full text query
-* **offset** (_int_) – offset this number of rows
-* **limit** (_int_) – maximum number of rows to return (default: 100)</li>
-* **fields** (_mixed_) – array or comma-separated string of fields to return (default: all fields in original order)
-* **sort** (_string_) – comma-separated field names with ordering
-* **join** (_array_) – array of fields to join from multiple tables
-
-### Parameter Format
-
-While the above can be passed as simple GET parameters (i.e. `?offset=1&limit=10`),  queries that join multiple tables require an extended syntax on some fields, following the pattern:
-
-`param_name[resource_alias][field_name]=value,value1`
-
-Even in a join query, this syntax will not be necessary for all parameters. For example, if you need to limit the number of records then you need to use the limit parameter. However it doesn't make sense to specify an alias or a field in such case, even if you are submitting a join query. See below for examples.
-
-## Return Values
-
-* **fields** (list of fields) – fields/columns and metadata
-* **offset** (int) – query offset value
-* **limit** (int) – query limit value
-* **count** (int) – number of total matching records
-* **records** (list of dictionaries) – list of matching results
+## Aggregation functions
+- **sum** (*string*) – field to compute the sum
+- **avg** (*string*) – field to compute the average
+- **min** (*string*) – field to compute the maximum
+- **max** (*string*) – field to compute the minimum
+- **std** (*string*) – field to compute the standard deviation
+- **variance** (*string*) – field to compute the variance
 
 
-## Examples
-The following is a simple example with two resources that contain 4 records each.
-
-**Resource 1** (UUID: `d2142282-9838-4cca-972f-f1741410417b`)**:**
+## URL format
+Params passed through URL shares a common shape:
 
 ```
-+---------+-------------+----+------------+
-| country | population  | id | timestamp  |
-+---------+-------------+----+------------+
-| US      | 315,209,000 |  1 | 1359062329 |
-| CA      | 35,002,447  |  2 | 1359062329 |
-| AR      | 40,117,096  |  3 | 1359062329 |
-| JP      | 127,520,000 |  4 | 1359062329 |
-+---------+-------------+----+------------+
+param_name<resource_alias>[field*name]=value,value1
 ```
+- **param_name**: the param you are using (e.g. offset)
+- **resource_alias(optional)**: an alias to reference an specific resource in further params.
+- **field_name(optional)**: a field name used by the param name.
+- **value**: a list of values divided by commas
 
-**Resource 1** (UUID: `d3c099c6-1340-4ee5-b030-8faf22b4b424`)**:**
+Notice resources and fields are optional and depends on what you want to query. For example if you need to limit the number of records then you need to use the limit parameter. However it doesn't make sense to specify an alias or a field in such case. You only need to provide the number of records you need to retrieve:
 
 ```
-+---------+-----------+----+------------+
-| country | squarekm  | id | timestamp  |
-+---------+-----------+----+------------+
-| US      | 9,629,091 |  1 | 1359062713 |
-| CA      | 9,984,670 |  2 | 1359062713 |
-| AR      | 2,780,400 |  3 | 1359062713 |
-| JP      | 377,930   |  4 | 1359062713 |
-+---------+-----------+----+------------+
+...&limit=5
 ```
 
-### Simple query example
+
+
+However there is one exception: 
+
+Even when the sort param share the previous declared shape it also accepts an alternative format:
 
 ```
-http://example.com/api/dataset/search?resource_id=d2142282-9838-4cca-972f-f1741410417b&filters[country]=AR,US&fields=country,population,timestamp&sort[country]=asc
+...&sort=field1,field2 desc 
 ```
 
-Returns the country, population, and timestamp fields for US and AR from dataset 1 sorting by the country in ascending order.
-
-### Text Search
-
-Paths with the 'query' argument will search the listed fields within the dataset.
-
-`http://example.com/api/dataset/search?resource_id=d2142282-9838-4cca-972f-f1741410417b&fields=country,population&query=US`
-
-This will return the country and population from US.
-
-### Joins
-
-If you wish to query multiple tables, indicate the table as an array key in the following fields:
-
-`http://example.com/api/dataset/search?resource_id[pop]=d2142282-9838-4cca-972f-f1741410417b&resource_id[size]=d3c099c6-1340-4ee5-b030-8faf22b4b424&filters[pop][country]=US,AR&join[pop]=country&join[size]=country`
-
-Returns the country, population, squarekm and id for US and AR from datasets 11 and 13.
 
 ## Multiple queries
 
-Sometimes you want to do mutiple queries in one request. This use-case has come up particularly when building [dashboard applications](https://github.com/NuCivic/react-dashboard) off the datastore API. You can post a json object to `/api/action/datastore/search.json` with all the queries to perform in a single request.
+Sometimes you want to do mutiple queries in one request (e.g. feed a data dashboard). If that your case you can post a json object to http://EXAMPLE.COM/api/action/datastore/search.json with all the queries to perform. 
 
 Request body should have a shape similar to this:
 
 ### Request body
 
-```json
+```javascript
 {
   "my_query": {
     "resource_id": {
@@ -121,13 +73,13 @@ Request body should have a shape similar to this:
       "gold_prices": "d3c099c6-1340-4ee5-b030-8faf22b4b424"
     },
     "limit": 5
-  }
+  }  
 }
 ```
 
 ### Response
 
-```json
+```javascript
 {
   "my_query": {
     "help": "Search a datastore table. :param resource_id: id or alias of the data that is going to be selected.",
@@ -135,7 +87,7 @@ Request body should have a shape similar to this:
     "result": {
       "fields": [
         {
-          "id": "name",
+          "id": "nombre",
           "type": "text"
         },
         {
@@ -151,11 +103,11 @@ Request body should have a shape similar to this:
       "total": 5,
       "records": [
         {
-          "name": "Alabama",
+          "nombre": "Alabama",
           "state_id": "1",
-          "feeds_flatstore_entry_id": "1",
+          "feeds*flatstore_entry*id": "1",
           "timestamp": "1466096874",
-          "feeds_entity_id": "13"
+          "feeds*entity*id": "13"
         }
       ]
     }
@@ -188,12 +140,91 @@ Request body should have a shape similar to this:
           "date": "1950-01-01",
           "price": "34.73",
           "state_id": "1",
-          "feeds_flatstore_entry_id": "1",
+          "feeds*flatstore_entry*id": "1",
           "timestamp": "1466036208",
-          "feeds_entity_id": "12"
+          "feeds*entity*id": "12"
         }
       ]
     }
   }
 }
 ```
+
+## Response formats
+Requests can be sent over HTTP. Data can be returned as JSON, XML, or JSONP. To retrieve data in a different format search extension in the url. 
+
+**Instead of using this:**
+
+```
+http://EXAMPLE.COM/api/action/datastore/search.json
+```
+
+**Use this:**
+```
+http://EXAMPLE.COM/api/action/datastore/search.xml
+```
+
+**Or this:**
+```
+http://EXAMPLE.COM/api/action/datastore/search.jsonp
+```
+
+## Limitations
+- The **q** param doesn't work in combination with the join param.
+- Filters doesn't work with float (decimals) values 
+
+## Examples
+The following is a simple example with two resources that contain 4 records each. Please note that the resource_id would be a UUID not single digit number in real scenario.
+
+**Resource: 1**
+```
++---------+-------------+----+------------+
+| country | population  | id | timestamp  |
++---------+-------------+----+------------+
+| US      | 315,209,000 |  1 | 1359062329 |
+| CA      | 35,002,447  |  2 | 1359062329 |
+| AR      | 40,117,096  |  3 | 1359062329 |
+| JP      | 127,520,000 |  4 | 1359062329 |
++---------+-------------+----+------------+
+```
+
+**Resource 2**
+```
++---------+-----------+----+------------+
+| country | squarekm  | id | timestamp  |
++---------+-----------+----+------------+
+| US      | 9,629,091 |  1 | 1359062713 |
+| CA      | 9,984,670 |  2 | 1359062713 |
+| AR      | 2,780,400 |  3 | 1359062713 |
+| JP      | 377,930   |  4 | 1359062713 |
++---------+-----------+----+------------+
+```
+
+
+**Simple query example:**
+
+```
+http://example.com/api/dataset/search?resource_id=d3c099c6-1340-4ee5-b030-8faf22b4b424&filters<country>=AR,US&fields=country,population,timestamp&sort[country]=asc
+```
+
+Returns the country, population, and timestamp fields for US and AR from dataset 1 sorting by the country in ascending order.
+
+**Text Search**
+Paths with the 'query' argument will search the listed fields within the dataset.
+
+
+```
+http://example.com/api/dataset/search?resource_id=d3c099c6-1340-4ee5-b030-8faf22b4b424&&fields=country,population&query=US
+```
+
+Will return the country and population from US
+
+**Joining**
+If you wish to query multiple tables, indicate the table as an array key in the following fields:
+
+```
+http://example.com/api/dataset/search?resource_id[pop]=d3c099c6-1340-4ee5-b030-8faf22b4b424&resource_id[size]=d3c099c6-1340-4ee5-b030-8faf22b4b424&filters[pop][country]=US,AR&join[pop]=country&join[size]=country
+```
+
+Returns the country, population, squarekm and id for US and AR from datasets 11 and 13.
+

--- a/modules/dkan_datastore_api/README.md
+++ b/modules/dkan_datastore_api/README.md
@@ -1,0 +1,199 @@
+DKAN offers a Datastore API as a custom endpoint for the Drupal Services module.
+
+This API is designed to be as compatible as possible with the [CKAN Datastore API](http://ckan.readthedocs.org/en/latest/maintaining/datastore.html).
+
+Requests can be sent over HTTP. Data can be returned as JSON, XML, or JSONP. The Datastore API supports both simple GET parameters and POST requests containing a JSON object specifying one or multiple queries.
+
+## Datastore API URL
+
+Datastores can be queried at:  `/api/action/datastore/search`
+
+The default return format is XML. JSON can be retrieved with `.json` at the end:
+
+`/api/action/datastore/search.json`
+
+...as can JSONP or making XML more explicit:
+
+`/api/action/datastore/search.jsonp`
+
+`/api/action/datastore/search.xml`
+
+## Request Parameters
+
+* **resource_id** (_mixed_) – id (string) or ids (array) of the resource to be searched against.
+* **filters** (_mixed_) – array or string of matching conditions to select
+* **q** (_string_) – full text query
+* **offset** (_int_) – offset this number of rows
+* **limit** (_int_) – maximum number of rows to return (default: 100)</li>
+* **fields** (_mixed_) – array or comma-separated string of fields to return (default: all fields in original order)
+* **sort** (_string_) – comma-separated field names with ordering
+* **join** (_array_) – array of fields to join from multiple tables
+
+### Parameter Format
+
+While the above can be passed as simple GET parameters (i.e. `?offset=1&limit=10`),  queries that join multiple tables require an extended syntax on some fields, following the pattern:
+
+`param_name[resource_alias][field_name]=value,value1`
+
+Even in a join query, this syntax will not be necessary for all parameters. For example, if you need to limit the number of records then you need to use the limit parameter. However it doesn't make sense to specify an alias or a field in such case, even if you are submitting a join query. See below for examples.
+
+## Return Values
+
+* **fields** (list of fields) – fields/columns and metadata
+* **offset** (int) – query offset value
+* **limit** (int) – query limit value
+* **count** (int) – number of total matching records
+* **records** (list of dictionaries) – list of matching results
+
+
+## Examples
+The following is a simple example with two resources that contain 4 records each.
+
+**Resource 1** (UUID: `d2142282-9838-4cca-972f-f1741410417b`)**:**
+
+```
++---------+-------------+----+------------+
+| country | population  | id | timestamp  |
++---------+-------------+----+------------+
+| US      | 315,209,000 |  1 | 1359062329 |
+| CA      | 35,002,447  |  2 | 1359062329 |
+| AR      | 40,117,096  |  3 | 1359062329 |
+| JP      | 127,520,000 |  4 | 1359062329 |
++---------+-------------+----+------------+
+```
+
+**Resource 1** (UUID: `d3c099c6-1340-4ee5-b030-8faf22b4b424`)**:**
+
+```
++---------+-----------+----+------------+
+| country | squarekm  | id | timestamp  |
++---------+-----------+----+------------+
+| US      | 9,629,091 |  1 | 1359062713 |
+| CA      | 9,984,670 |  2 | 1359062713 |
+| AR      | 2,780,400 |  3 | 1359062713 |
+| JP      | 377,930   |  4 | 1359062713 |
++---------+-----------+----+------------+
+```
+
+### Simple query example
+
+```
+http://example.com/api/dataset/search?resource_id=d2142282-9838-4cca-972f-f1741410417b&filters[country]=AR,US&fields=country,population,timestamp&sort[country]=asc
+```
+
+Returns the country, population, and timestamp fields for US and AR from dataset 1 sorting by the country in ascending order.
+
+### Text Search
+
+Paths with the 'query' argument will search the listed fields within the dataset.
+
+`http://example.com/api/dataset/search?resource_id=d2142282-9838-4cca-972f-f1741410417b&fields=country,population&query=US`
+
+This will return the country and population from US.
+
+### Joins
+
+If you wish to query multiple tables, indicate the table as an array key in the following fields:
+
+`http://example.com/api/dataset/search?resource_id[pop]=d2142282-9838-4cca-972f-f1741410417b&resource_id[size]=d3c099c6-1340-4ee5-b030-8faf22b4b424&filters[pop][country]=US,AR&join[pop]=country&join[size]=country`
+
+Returns the country, population, squarekm and id for US and AR from datasets 11 and 13.
+
+## Multiple queries
+
+Sometimes you want to do mutiple queries in one request. This use-case has come up particularly when building [dashboard applications](https://github.com/NuCivic/react-dashboard) off the datastore API. You can post a json object to `/api/action/datastore/search.json` with all the queries to perform in a single request.
+
+Request body should have a shape similar to this:
+
+### Request body
+
+```json
+{
+  "my_query": {
+    "resource_id": {
+      "states": "d2142282-9838-4cca-972f-f1741410417b",
+      "gold_prices":"d3c099c6-1340-4ee5-b030-8faf22b4b424"
+    },
+    "limit": 5
+  },
+  "my_query1": {
+    "resource_id": {
+      "gold_prices": "d3c099c6-1340-4ee5-b030-8faf22b4b424"
+    },
+    "limit": 5
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "my_query": {
+    "help": "Search a datastore table. :param resource_id: id or alias of the data that is going to be selected.",
+    "success": true,
+    "result": {
+      "fields": [
+        {
+          "id": "name",
+          "type": "text"
+        },
+        {
+          "id": "state_id",
+          "type": "int"
+        }
+      ],
+      "resource_id": {
+        "states": "d2142282-9838-4cca-972f-f1741410417b",
+        "gold_prices": "d3c099c6-1340-4ee5-b030-8faf22b4b424"
+      },
+      "limit": 1,
+      "total": 5,
+      "records": [
+        {
+          "name": "Alabama",
+          "state_id": "1",
+          "feeds_flatstore_entry_id": "1",
+          "timestamp": "1466096874",
+          "feeds_entity_id": "13"
+        }
+      ]
+    }
+  },
+  "my_query1": {
+    "help": "Search a datastore table. :param resource_id: id or alias of the data that is going to be selected.",
+    "success": true,
+    "result": {
+      "fields": [
+        {
+          "id": "date",
+          "type": "datetime"
+        },
+        {
+          "id": "price",
+          "type": "float"
+        },
+        {
+          "id": "state_id",
+          "type": "int"
+        }
+      ],
+      "resource_id": {
+        "gold_prices": "d3c099c6-1340-4ee5-b030-8faf22b4b424"
+      },
+      "limit": 1,
+      "total": 748,
+      "records": [
+        {
+          "date": "1950-01-01",
+          "price": "34.73",
+          "state_id": "1",
+          "feeds_flatstore_entry_id": "1",
+          "timestamp": "1466036208",
+          "feeds_entity_id": "12"
+        }
+      ]
+    }
+  }
+}
+```

--- a/modules/dkan_datastore_api/dkan_datastore_api.info
+++ b/modules/dkan_datastore_api/dkan_datastore_api.info
@@ -3,4 +3,3 @@ description = Access datastore info over json.
 package = DKAN API
 core = 7.x
 dependencies[] = services
-files[] = tests/dkan_datastore_api.test

--- a/modules/dkan_datastore_api/dkan_datastore_api.module
+++ b/modules/dkan_datastore_api/dkan_datastore_api.module
@@ -93,72 +93,20 @@ function dkan_datastore_api_services_resources() {
         ),
         'description' => 'Data API for DKAN datastores',
         'callback' => '_dkan_datastore_api_datastore_index',
-        'args' => array(
-          array(
-            'name' => 'resource_id',
-            'optional' => TRUE,
-            'type' => 'array',
-            'description' => 'id or alias of the resource to be searched against.',
-            'default value' => 0,
-            'source' => array('param' => 'resource_id'),
-          ),
-          array(
-            'name' => 'filters',
-            'optional' => TRUE,
-            'type' => 'string',
-            'description' => 'matching conditions to select.',
-            'default value' => 0,
-            'source' => array('param' => 'filters'),
-          ),
-          array(
-            'name' => 'query',
-            'optional' => TRUE,
-            'type' => 'string',
-            'description' => 'matching conditions to select.',
-            'default value' => 0,
-            'source' => array('param' => 'query'),
-          ),
-          array(
-            'name' => 'offset',
-            'optional' => TRUE,
-            'type' => 'int',
-            'description' => 'offset this number of rows',
-            'default value' => 0,
-            'source' => array('param' => 'offset'),
-          ),
-          array(
-            'name' => 'limit',
-            'optional' => TRUE,
-            'type' => 'int',
-            'description' => 'maximum number of rows to return (default: 100).',
-            'default value' => variable_get('dkan_datastore_api_index_limit', 100),
-            'source' => array('param' => 'limit'),
-          ),
-          array(
-            'name' => 'fields',
-            'optional' => TRUE,
-            'type' => array(),
-            'description' => 'fields to return as a list or comma separated string (default: all fields in original order).',
-            'default value' => '*',
-            'source' => array('param' => 'fields'),
-          ),
-          array(
-            'name' => 'sort',
-            'optional' => TRUE,
-            'type' => 'string',
-            'description' => 'comma separated field names with ordering e.g.: “fieldname1, fieldname2 desc.',
-            'default value' => '',
-            'source' => array('param' => 'sort'),
-          ),
-          array(
-            'name' => 'join',
-            'optional' => TRUE,
-            'type' => 'array',
-            'description' => 'array of values to join on if including multiple datasets.',
-            'default value' => '',
-            'source' => array('param' => 'join'),
-          ),
+        'args' => array(),
+        'access callback' => '_dkan_datastore_api_datastore_access',
+        'access arguments' => array('view'),
+        'access arguments append' => FALSE,
+      ),
+      'create' => array(
+        'file' => array(
+          'type' => 'inc',
+          'module' => 'services',
+          'name' => 'resources/user_resource',
         ),
+        'description' => 'Data API for DKAN datastores',
+        'callback' => '_dkan_datastore_api_datastore_index',
+        'args' => array(),
         'access callback' => '_dkan_datastore_api_datastore_access',
         'access arguments' => array('view'),
         'access arguments append' => FALSE,
@@ -275,16 +223,107 @@ function dkan_datastore_api_services_resources() {
  *
  * For arguments, see: dkan_datastore_api_services_resources().
  */
-function _dkan_datastore_api_datastore_index($resource_ids, $filters, $query, $offset, $limit, $fields, $sort, $join) {
+function _dkan_datastore_api_datastore_index() {
+  if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+    $params = _dkan_datastore_api_get_params();
+    $result = _dkan_datastore_api_query($params);
+  }
+  elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $result = _dkan_datastore_api_multiple_query();
+  }
+  return $result;
+}
+
+/**
+ * Performs a multiple query against the datastore.
+ */
+function _dkan_datastore_api_get_params($params = array()) {
+  $params = !empty($params) ? (array) $params : drupal_get_query_parameters();
+  $params['resource_ids'] = $params['resource_id'];
+  $defaults = array(
+    'resource_ids' => array(),
+    'fields' => '*',
+    'sort' => '',
+    'filters' => array(),
+    'join' => array(),
+    'query' => '',
+    'offset' => 0,
+    'limit' => 10,
+    'group_by' => array(),
+    'avg' => '',
+    'sum' => '',
+    'min' => '',
+    'max' => '',
+    'count' => '',
+  );
+  $params = array_merge($defaults, $params);
+  $sort = dkan_datastore_api_sort_clean($params['sort']);
+  $fields = _dkan_datastore_api_fields_clean($params['fields']);
+  $aggregations = array(
+    'sum' => $params['sum'],
+    'avg' => $params['avg'],
+    'min' => $params['min'],
+    'max' => $params['max'],
+    'count' => $params['count'],
+  );
+  unset($params['resource_id']);
+  $params = array_intersect_key($params, $defaults);
+  return array_merge($params, array(
+    'aggregations' => $aggregations,
+    'sort' => $sort,
+    'fields' => $fields,
+  ));
+}
+
+/**
+ * Field safe name.
+ *
+ * It depends on the feeds_flatstore_processor_safe_name.
+ * I decided to wrap it to make easy to decouple it.
+ */
+function _dkan_datastore_api_field_safe_name($field) {
+  return feeds_flatstore_processor_safe_name($field);
+}
+
+/**
+ * Clean fields.
+ */
+function _dkan_datastore_api_fields_clean($fields) {
+  if ($fields == '*') {
+    return $fields;
+  }
+  elseif (is_array($fields)) {
+    return array_map('_dkan_datastore_api_field_safe_name', $fields);
+  }
+  elseif (is_string($fields)) {
+    return array_map('_dkan_datastore_api_field_safe_name', explode(',', $fields));
+  }
+}
+
+/**
+ * Performs a single query against the datastore.
+ */
+function _dkan_datastore_api_query($params) {
+  extract($params);
+  $data_select = NULL;
+  $aggregations = array(
+    'sum' => $sum,
+    'avg' => $avg,
+    'max' => $max,
+    'min' => $min,
+    'count' => $count,
+  );
+
   try {
     // Query for a single resource.
     if (count($resource_ids) < 2) {
-      $ids = array_values($resource_ids);
+      $ids = array_values((array) $resource_ids);
       $resource_id = array_shift($ids);
       $table = dkan_datastore_api_tablename($resource_id);
-      $sort = dkan_datastore_api_sort_clean($sort);
       $data_select = dkan_datastore_api_build_index_query($table, $offset, $limit, $fields, $sort);
       dkan_datastore_api_add_index_conditions($data_select, $filters);
+      dkan_datastore_api_add_index_group_by($data_select, $group_by);
+      dkan_datastore_api_add_index_aggregations($data_select, $aggregations);
     }
     // Query for a multiple resources.
     else {
@@ -301,66 +340,115 @@ function _dkan_datastore_api_datastore_index($resource_ids, $filters, $query, $o
           $sort = isset($sort[$alias]) ? $sort[$alias] : $sort;
           $filters = isset($filters[$alias]) ? $filters[$alias] : $filters;
           $data_select = dkan_datastore_api_build_index_query($table, $offset, $limit, $fields, $sort, $alias);
-          dkan_datastore_api_add_index_conditions($data_select, $filters, $alias);
         }
         // For the additional resources we are adding joins, fields, filters.
         else {
           $newfields = isset($fields[$alias]) ? $fields[$alias] : '*';
           $sort = isset($sort[$alias]) ? $sort[$alias] : '';
           $filters = isset($filters[$alias]) ? $filters[$alias] : '';
-
           dkan_datastore_api_build_additional_index_query($data_select, $table, $fields, $sort, $alias, $join);
-          if ($filters) {
-            dkan_datastore_api_add_index_conditions($data_select, $filters, $alias);
-          }
         }
+        dkan_datastore_api_add_index_conditions($data_select, $filters, $alias);
+        dkan_datastore_api_add_index_group_by($data_select, $group_by, $alias);
+        dkan_datastore_api_add_index_aggregations($data_select, $aggregations, $alias);
         $i++;
       }
     }
     if ($query && $query != 'api/3/action/datastore_search') {
       dkan_datastore_api_add_index_query($data_select, $table, $query);
     }
+    $count = dkan_datastore_api_count($data_select);
+    $results = services_resource_execute_index_query($data_select);
+    return dkan_datastore_api_resource_build_index_list($data_select, $results, $table, $fields, $resource_ids, $count, $limit);
   }
   catch (Exception $ex) {
-    return array('error' => array('message' => 'Caught exception: ' . $ex->getMessage()));
+    return array('sql' => dkan_datastore_api_debug($data_select), 'error' => array('message' => 'Caught exception: ' . $ex->getMessage()));
   }
-  $count = dkan_datastore_api_count($table, $offset, $limit, $fields, $filters, $query);
-  $results = services_resource_execute_index_query($data_select);
-  return dkan_datastore_api_resource_build_index_list($results, $table, $fields, $resource_ids, $count);
+}
+
+/**
+ * Performs a multiple query against the datastore.
+ */
+function _dkan_datastore_api_multiple_query($queries) {
+  $request_body = $queries ? $queries : json_decode(file_get_contents('php://input'));
+  $queries = $request_body;
+  foreach ((array) $queries as $name => $query) {
+    $params = _dkan_datastore_api_get_params($query);
+    $result[$name] = _dkan_datastore_api_query($params);
+  }
+  return $result;
 }
 
 /**
  * Retrieves count given fully query without paging limit.
  */
-function dkan_datastore_api_count($table, $offset, $limit, $fields, $filters, $query) {
-
-  $count_select = db_select($table, 'counter');
-  $count_select->addExpression('COUNT(feeds_flatstore_entry_id)', 'count');
-  if ($filters) {
-    dkan_datastore_api_add_index_conditions($count_select, $filters, 'counter');
-  }
-  if ($query) {
-    dkan_datastore_api_add_index_query($count_select, $table, $query);
-  }
-  $result = $count_select->execute()->fetchAll();
-  return $result[0]->count;
+function dkan_datastore_api_count($data_select) {
+  $query = clone($data_select);
+  $count = $query->range()->execute()->fetchAll();
+  return count($count);
 }
 
 /**
  * Adds conditions, ie WHERE clause, to query.
  */
 function dkan_datastore_api_add_index_conditions(&$data_select, $filters, $alias = 't') {
-  if (is_array($filters)) {
+  $filters = dkan_datastore_api_qualify_filters($filters);
+  if ($filters && is_array($filters)) {
     foreach ($filters as $num => $filter) {
       $num = str_replace(' ', '_', $num);
-      if (is_array($filter)) {
-        foreach ($filter as $key => $value) {
-          $data_select->condition($num . '.' . $key, $filter, 'IN');
-        }
+      foreach ($filter as $key => $value) {
+        $data_select->condition($key, $filter, 'IN');
       }
-      else {
-        $data_select->condition($alias . '.' . $num, services_str_getcsv($filter), 'IN');
+    }
+  }
+}
+
+/**
+ * Process filters to use qualified field names.
+ *
+ * @param  Array $filters Unprocesed filters
+ * @return Array          Flat array with qualified names
+ */
+function dkan_datastore_api_qualify_filters($filters) {
+  $result = array();
+  foreach ($filters as $num => $filterValue) {
+    if(is_array($filterValue)) {
+      foreach ($filterValue as $field => $value) {
+        $result[$num . '.' . $field] = $value;
       }
+    } else {
+      $result[$num] = $filterValue;
+    }
+  }
+  return $result;
+}
+
+/**
+ * Adds group by statements to query.
+ */
+function dkan_datastore_api_add_index_group_by(&$data_select, $group_by, $alias = 't') {
+  if (empty($group_by)) {
+    return;
+  }
+  $group_by = $alias && isset($group_by[$alias]) ? $group_by[$alias] : $group_by;
+  if ($group_by) {
+    $group_by = (is_array($group_by)) ? $group_by : services_str_getcsv($group_by);
+    foreach ($group_by as $field) {
+      $data_select->groupBy($alias . '.' . _dkan_datastore_api_field_safe_name($field));
+    }
+  }
+}
+
+/**
+ * Adds aggregations to query.
+ */
+function dkan_datastore_api_add_index_aggregations(&$data_select, $aggregations, $alias = NULL) {
+  foreach ($aggregations as $method => $agg) {
+    $field_name = $alias && is_array($agg) && isset($agg[$alias]) ? $agg[$alias] : $agg;
+    $field_full = $alias ? $alias . '.' . $field_name : $field_name;
+
+    if (!empty($field_name)) {
+      $data_select->addExpression($method . '(' . _dkan_datastore_api_field_safe_name($field_full) . ')', $method . '_' . _dkan_datastore_api_field_safe_name($field_name));
     }
   }
 }
@@ -380,7 +468,7 @@ function dkan_datastore_api_add_index_query(&$data_select, $table, $query) {
     }
     if (count($ft_fields)) {
       $field_list = implode(', ', $ft_fields);
-      $data_select->where("MATCH($field_list) AGAINST (:query)", array(':query' => $query));
+      $data_select->where("MATCH($field_list) AGAINST (:query IN BOOLEAN MODE)", array(':query' => $query));
       return;
     }
   }
@@ -400,7 +488,7 @@ function dkan_datastore_api_add_index_query(&$data_select, $table, $query) {
     }
   }
   else {
-    throw new Exception('No text search compatable fields on this datastore.');
+    throw new Exception('No text search compatible fields on this datastore.');
   }
 }
 
@@ -428,6 +516,9 @@ function dkan_datastore_api_build_additional_index_query(&$data_select, $table, 
  * Makes sure we are using column names for sorts.
  */
 function dkan_datastore_api_sort_clean($sort) {
+  if (is_array($sort)) {
+    return $sort;
+  }
   if (strpos($sort, ' asc') !== FALSE) {
     $type = 'asc';
   }
@@ -437,9 +528,10 @@ function dkan_datastore_api_sort_clean($sort) {
   else {
     return $sort;
   }
+
   $sort = explode(" $type", $sort);
   foreach ($sort as $key => $value) {
-    $sort[$key] = feeds_flatstore_processor_safe_name($value);
+    $sort[$key] = _dkan_datastore_api_field_safe_name($value);
   }
   $sort = implode(" $type", $sort);
   return $sort;
@@ -466,6 +558,7 @@ function dkan_datastore_api_tablename($resource_id) {
     return $tables[$resource_id];
   }
 }
+
 /**
  * Retrieves source_id from feeds_source.
  */
@@ -473,19 +566,30 @@ function dkan_datastore_api_get_feeds_source($nid) {
   $source_id = db_query("SELECT id FROM {feeds_source} WHERE feed_nid = :nid AND source != ''", array(':nid' => $nid))->fetchField();
   return $source_id ? $source_id : NULL;
 }
+
 /**
  * Builds index query.
  */
 function dkan_datastore_api_build_index_query($table, $offset, $limit, $fields, $sort, $alias = 't') {
-  $sort = explode(" ", $sort);
   $data_select = db_select($table, $alias);
-  if (isset($sort) && !empty($sort[0])) {
-    foreach (explode(",", $sort[0]) as $field) {
-      $data_select->orderBy($alias . '.' . $field, $sort[1]);
-    }
+
+  if (!is_array($sort)) {
+    $sort = explode(' ', $sort);
+    $order = $sort[0];
+    $columns = empty($sort) ? $sort : explode(',', $sort[0]);
   }
   else {
+    $columns = $sort;
+  }
+
+  if (count($columns) == 1 && array_values($columns)[0] == '') {
+
     $data_select->orderBy($alias . '.feeds_flatstore_entry_id', 'ASC');
+  }
+  else {
+    foreach ($columns as $field => $order) {
+      $data_select->orderBy($alias . '.' . $field, $order);
+    }
   }
   dkan_datastore_api_resource_build_index_query($data_select, $offset, $fields, $limit, $alias, $table);
   return $data_select;
@@ -495,7 +599,7 @@ function dkan_datastore_api_build_index_query($table, $offset, $limit, $fields, 
  * Same as services version but not adding conditions.
  */
 function dkan_datastore_api_resource_build_index_query(&$query, $page, $fields, $page_size, $alias, $table) {
-  $default_limit = variable_get("dkan_datastore_default_page_size", 100);
+  $default_limit = variable_get('dkan_datastore_default_page_size', 100);
   if ((!user_access('perform unlimited index queries') && $page_size > $default_limit) || !$page_size) {
     $page_size = $default_limit;
   }
@@ -504,7 +608,8 @@ function dkan_datastore_api_resource_build_index_query(&$query, $page, $fields, 
     $query->fields($alias);
   }
   else {
-    $query->fields($alias, explode(',', $fields));
+    $fields = is_array($fields) ? $fields : explode(',', $fields);
+    $query->fields($alias, $fields);
   }
 }
 
@@ -518,11 +623,9 @@ function _dkan_datastore_api_datastore_access($op) {
 /**
  * Builds index link with results of the query.
  */
-function dkan_datastore_api_resource_build_index_list($results, $table, $fields, $resource_ids, $count) {
+function dkan_datastore_api_resource_build_index_list($data_select, $results, $table, $fields, $resource_ids, $count, $limit) {
   // Put together array of matching items to return.
   $items = array();
-  $endpoint_name = services_get_server_info('endpoint');
-  $endpoint = services_endpoint_load($endpoint_name);
   foreach ($results as $result) {
     $items[] = $result;
   }
@@ -553,6 +656,7 @@ function dkan_datastore_api_resource_build_index_list($results, $table, $fields,
     $meta = '';
   }
   $return = new stdClass();
+
   if ($fields == '*') {
     foreach ($schema['fields'] as $name => $field) {
       // Don't include fields added by feeds_flatstore_processor.
@@ -576,13 +680,10 @@ function dkan_datastore_api_resource_build_index_list($results, $table, $fields,
     $fields = $output_fields;
   }
   $return->resource_id = $resource_ids;
-  $return->limit = count($items);
-  $query = db_select($table, 't');
-  $query->addExpression('count(t.timestamp)', 'count');
-  $total = $query->execute()->fetchCol();
-  $return->total = $count;
+  $return->limit = (int) $limit;
+  $return->total = (int) $count;
   $return->records = $items;
-
+  $return->sql = (string) $data_select;
   return $help + $success + array('result' => $return);
 }
 
@@ -783,4 +884,11 @@ function process_file_argument($file) {
   file_usage_add($file_saved, 'dkan_datastore_api', 'files', $file_saved->fid);
 
   return $file_saved;
+}
+
+/**
+ * Returns sql statement for debug purposes.
+ */
+function dkan_datastore_api_debug($data_select) {
+  return array('sql' => (string) $data_select);
 }

--- a/modules/dkan_datastore_api/dkan_datastore_api.module
+++ b/modules/dkan_datastore_api/dkan_datastore_api.module
@@ -370,7 +370,7 @@ function _dkan_datastore_api_query($params) {
  * Performs a multiple query against the datastore.
  */
 function _dkan_datastore_api_multiple_query($queries) {
-  $request_body = $queries ? $queries : json_decode(file_get_contents('php://input'));
+  $request_body = $queries ? $queries : json_decode(file_get_contents('php://input'),true);
   $queries = $request_body;
   foreach ((array) $queries as $name => $query) {
     $params = _dkan_datastore_api_get_params($query);

--- a/modules/dkan_datastore_api/dkan_datastore_api.module
+++ b/modules/dkan_datastore_api/dkan_datastore_api.module
@@ -394,14 +394,14 @@ function dkan_datastore_api_count($data_select) {
 function dkan_datastore_api_add_index_conditions(&$data_select, $filters, $alias = 't') {
   $filters = dkan_datastore_api_qualify_filters($filters);
   if ($filters && is_array($filters)) {
-    foreach ($filters as $num => $filter) {
-      $num = str_replace(' ', '_', $num);
-      foreach ($filter as $key => $value) {
-        $data_select->condition($key, $filter, 'IN');
-      }
+    foreach ($filters as $field => $value) {
+      $field = str_replace(' ', '_', $field);
+      $value = explode(',', $value);
+      $data_select->condition($field, $value, 'IN');
     }
   }
 }
+
 
 /**
  * Process filters to use qualified field names.

--- a/modules/dkan_datastore_api/dkan_datastore_api.services.inc
+++ b/modules/dkan_datastore_api/dkan_datastore_api.services.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Dkan_datastore_api.services.inc.
@@ -44,6 +45,9 @@ function dkan_datastore_api_default_services_endpoint() {
       'alias' => 'search',
       'operations' => array(
         'index' => array(
+          'enabled' => '1',
+        ),
+        'create' => array(
           'enabled' => '1',
         ),
       ),


### PR DESCRIPTION
Issue: CIVIC-5148

## Description

Upgrade dkan_datastore_api module to the most recent version. There are some functionality implemented in the newer version that are required by clients. However, we have most of clients using dkan 1.12 at this moment.

## QA Tests
- [ ] Create two resources (files attached in the reference issue)
- [ ] Perform a query following the reference issue
- [ ] No errors should be displayed and results should be retrieved
