### PR TITLE
Group Pages Have Manage Datastore Button (release) Civic 5295

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+7.x-1.12.14
+----------------------
+- Fix the "Manage Datastore" tab displaying on group nodes.
+
 7.x-1.12.13 2017-01-04
 ----------------------
 - Add limit to proxy resources.

--- a/dkan_datastore.module
+++ b/dkan_datastore.module
@@ -158,7 +158,7 @@ function dkan_datastore_feeds_access($action, $node) {
   }
 
   // All available operations requires the 'manage datastore' permission.
-  if (user_access('manage datastore') && node_access('update', $node)) {
+  if (user_access('manage datastore') && node_access('update', $node) && $node->type == 'resource') {
     return TRUE;
   }
 


### PR DESCRIPTION
# Description
Group pages have an additional button for all roles called Manage Datastore that isn't present in 1.12.11. Verified on ND Prod and USVA Prod/Test sites.

This was fixed in DKAN 1.13 NuCivic/dkan#1588

## QA Steps

1. log in and visit a groups page
2. confirm you do not see a 'Manage Datastore' tab