### PR TITLE
Updated services module to v 3.19

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -35,6 +35,7 @@ dependencies:
      #- "~/backups"
      #- "test/sites/default"
   pre:
+    - apt-get update
     - echo "memory_limit = 256M" > ~/.phpenv/versions/5.5.11/etc/conf.d/memory.ini
   override:
     - mkdir $CIRCLE_ARTIFACTS/junit

--- a/circle.yml
+++ b/circle.yml
@@ -35,7 +35,7 @@ dependencies:
      #- "~/backups"
      #- "test/sites/default"
   pre:
-    - apt-get update
+    - sudo apt-get update
     - echo "memory_limit = 256M" > ~/.phpenv/versions/5.5.11/etc/conf.d/memory.ini
   override:
     - mkdir $CIRCLE_ARTIFACTS/junit

--- a/dkan_datastore.make
+++ b/dkan_datastore.make
@@ -27,7 +27,7 @@ projects[schema][subdir] = contrib
 projects[schema][download][revision] = "08b02458694d186f8ab3bd0b24fbc738f9271108"
 
 projects[services][subdir] = contrib
-projects[services][version] = 3.16
+projects[services][version] = 3.19
 
 projects[data][subdir] = contrib
 projects[data][version] = 1.x


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-5965

## Description

We need to update service to 3.19. The last version fix some problems with security. 

## QA Steps

- [ ] Check service module version is 3.19

## Reminders
- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
